### PR TITLE
Multi-GPU z-parallel BaSiC fitting (~2x speedup)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: ty
         name: ty (type check)
-        entry: uv run --frozen ty check
+        entry: uv run --frozen ty check linum_basic/
         language: system
         types: [python]
         files: ^linum_basic/

--- a/linum_basic/_alm.py
+++ b/linum_basic/_alm.py
@@ -57,7 +57,18 @@ def shrink[ArrayT](xp: ArrayNamespace, theta: ArrayT, epsilon: float = 1e-3) -> 
     return xp.copysign(xp.maximum(xp.abs(theta) - epsilon, 0.0), theta)
 
 
-def _build_alm_step(xp: ArrayNamespace, n: int, p: int, q: int, l_s: float) -> Any:
+def _build_alm_step(
+    xp: ArrayNamespace,
+    n: int,
+    p: int,
+    q: int,
+    l_s: float,
+    *,
+    estimate_darkfield: bool = False,
+    l_d: float = 0.0,
+    ent2: float = 10.0,
+    b1_uplimit: float = 0.0,
+) -> Any:
     """Return a (possibly compiled) per-iteration ALM step function.
 
     The returned callable is cached by ``(backend, device, n, p, q, l_s)`` so
@@ -65,7 +76,17 @@ def _build_alm_step(xp: ArrayNamespace, n: int, p: int, q: int, l_s: float) -> A
     across different :class:`~linum_basic.core.BaSiC` instances that share
     the same problem shape and regularisation weight.
     """
-    cache_key = (xp._backend.value, getattr(xp, "device", ""), n, p, q, l_s)
+    device_key = str(getattr(xp, "_device", ""))
+    cache_key = (
+        xp._backend.value,
+        device_key,
+        n,
+        p,
+        q,
+        l_s,
+        estimate_darkfield,
+        l_d,
+    )
     if cache_key in _ALM_STEP_CACHE:
         return _ALM_STEP_CACHE[cache_key]
 
@@ -106,8 +127,9 @@ def _build_alm_step(xp: ArrayNamespace, n: int, p: int, q: int, l_s: float) -> A
         d_field: Any,
         y: Any,
         w: Any,
-        cur_mu: float,
-    ) -> tuple[Any, Any, Any, Any, Any, Any, Any, Any]:
+        cur_mu: Any,
+        b1: Any,
+    ) -> tuple[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]:
         y_f32 = xp.astype(y / cur_mu, np.float32)
         # Step 1: update Ir using S_spatial from the previous iteration.
         ib_old = s_spatial * b + d_field
@@ -125,9 +147,50 @@ def _build_alm_step(xp: ArrayNamespace, n: int, p: int, q: int, l_s: float) -> A
         r_mean_row = xp.mean(d_minus_ir, axis=1, keepdims=True)
         new_r_mean_all = xp.mean(d_minus_ir)
         new_b = xp.astype(xp.maximum(r_mean_row / (new_r_mean_all + 1e-9), 0.0), np.float32)
-        # dY for Lagrange update (caller only needs it after darkfield step).
+        # dY for Lagrange update (uses D_field before darkfield refresh).
         d_y = d - new_ib - new_ir
-        return new_sf, new_s_spatial, new_ib, new_ir, d_minus_ir, new_b, new_r_mean_all, d_y
+        new_d_field = d_field
+        new_b1 = b1
+        if estimate_darkfield:
+            s_mean = xp.mean(new_s_spatial)
+            mask_valid_b_f = xp.astype((new_b < 1.0)[:, 0], np.float32)
+            mask_high_s_f = xp.astype(new_s_spatial[0] > (s_mean - 1e-6), np.float32)
+            mask_low_s_f = xp.astype(new_s_spatial[0] < (s_mean + 1e-6), np.float32)
+            k_cnt = xp.sum(mask_valid_b_f)
+            dminus_ir_valid_rowsum = xp.sum(d_minus_ir * mask_valid_b_f[:, None], axis=0, keepdims=True)
+            n_high = xp.sum(mask_high_s_f)
+            n_low = xp.sum(mask_low_s_f)
+            r_high = xp.sum(dminus_ir_valid_rowsum * mask_high_s_f[None, :]) / (k_cnt * n_high + 1e-9)
+            r_low = xp.sum(dminus_ir_valid_rowsum * mask_low_s_f[None, :]) / (k_cnt * n_low + 1e-9)
+            b1_cand = (r_high - r_low) / (new_r_mean_all + 1e-9)
+            b_flat = xp.astype(new_b[:, 0], np.float32)
+            sum_b2 = xp.sum(b_flat**2 * mask_valid_b_f)
+            sum_b = xp.sum(b_flat * mask_valid_b_f)
+            temp1 = sum_b2
+            temp2 = sum_b
+            temp3 = b1_cand * k_cnt
+            temp4 = xp.sum(b_flat * b1_cand * mask_valid_b_f)
+            denom = temp2 * temp3 - k_cnt * temp4
+            b1_new_raw = (temp1 * temp3 - temp2 * temp4) / (denom + 1e-30)
+            b1_new_guarded = xp.where(xp.abs(denom) > 1e-30, b1_new_raw, b1)
+            b1_new = xp.minimum(b1_new_guarded, b1_uplimit / (s_mean + 1e-9))
+            new_b1 = xp.where(b1_new > 0.0, b1_new, b1)
+            z = new_b1 * (s_mean - new_s_spatial)
+            k_cnt_f64 = xp.astype(k_cnt, np.float64)
+            sum_b_f64 = xp.astype(sum_b, np.float64)
+            s64 = xp.astype(new_s_spatial, np.float64)
+            d_valid_rowsum_f64 = xp.astype(dminus_ir_valid_rowsum, np.float64)
+            b_valid_mean = sum_b_f64 / (k_cnt_f64 + 1e-30)
+            a1_offset = d_valid_rowsum_f64 / (k_cnt_f64 + 1e-30) - b_valid_mean * s64
+            a_offset = a1_offset - xp.astype(z, np.float64)
+            a_offset_mean = xp.mean(a_offset)
+            a_offset_centered = xp.astype(a_offset - a_offset_mean, np.float32)
+            dr_f = xp.astype(_dctn2(a_offset_centered.reshape(p, q)), np.float32)
+            dr_f_shrunk = shrink(xp, dr_f, l_d / (ent2 * cur_mu))
+            dr = xp.astype(_idctn2(dr_f_shrunk.reshape(p, q)), np.float32).reshape(1, p * q)
+            dr = shrink(xp, dr, l_d / (cur_mu * ent2))
+            new_d_field = xp.astype(dr + xp.astype(a_offset_mean, np.float32) + z, np.float32)
+        return new_sf, new_s_spatial, new_ib, new_ir, d_minus_ir, new_b, new_r_mean_all, d_y, new_d_field, new_b1
 
     fn: Any = _alm_core_step
     if xp._backend is not Backend.NUMPY:
@@ -326,7 +389,17 @@ def inexact_alm_l1(
     # Steps 1-4 are a pure-tensor function compiled once per unique
     # (backend, device, n, p, q, l_s) combination and cached at module scope.
     # ------------------------------------------------------------------
-    _alm_core_step = _build_alm_step(xp, n, p, q, l_s)
+    _alm_core_step = _build_alm_step(
+        xp,
+        n,
+        p,
+        q,
+        l_s,
+        estimate_darkfield=estimate_darkfield,
+        l_d=l_d,
+        ent2=ent2,
+        b1_uplimit=B1_uplimit,
+    )
 
     # ------------------------------------------------------------------
     # Main loop  (gradient tracking disabled for torch backends)
@@ -339,77 +412,12 @@ def inexact_alm_l1(
         mu: Any = xp.asarray(np.array(mu_scalar, dtype=np.float32))
         mu_bar: Any = xp.asarray(np.array(mu_bar_scalar, dtype=np.float32))
         while not converged and iteration < max_iter:
-            # Steps 1-4: Ir / Sf / S_spatial / Ib / B update (compiled when on GPU).
-            Sf, S_spatial, Ib, Ir, DminusIr, B, R_mean_all, dY = _alm_core_step(D, S_spatial, B, D_field, Y, W, mu)
-            # On the first iteration the fed-back tensors (B, S_spatial,
-            # D_field, Y) carry the plain {CUDA, BackendSelect} dispatch key
-            # (created outside inference_mode).  From iteration 2 they are
-            # updated inside inference_mode and carry InferenceMode.  This
-            # one-time key change triggers a single torch._dynamo guard failure
-            # and recompile.  Cloning B and S_spatial (the two tensors returned
-            # from the compiled step) strips any residual view keys and keeps
-            # them consistent; xp.clone() is a no-op on NumPy.
+            # Steps 1-5: flat-field, baseline, optional dark-field (compiled on GPU).
+            Sf, S_spatial, Ib, Ir, _DminusIr, B, _R_mean_all, dY, D_field, B1 = _alm_core_step(
+                D, S_spatial, B, D_field, Y, W, mu, B1
+            )
             B = xp.clone(B)
             S_spatial = xp.clone(S_spatial)
-            # When k_cnt == 0 (no valid rows), the masked sums are naturally
-            # zero so the formulas produce well-defined zero results without
-            # any Python branching on device values.
-            if estimate_darkfield:
-                S_mean = xp.mean(S_spatial)  # scalar f32 tensor, no sync
-                mask_valid_b_f = xp.astype((B < 1.0)[:, 0], np.float32)  # (N,)
-                mask_high_s_f = xp.astype(S_spatial[0] > (S_mean - 1e-6), np.float32)  # (P*Q,)
-                mask_low_s_f = xp.astype(S_spatial[0] < (S_mean + 1e-6), np.float32)  # (P*Q,)
-
-                # k_cnt: number of valid rows — scalar f32 tensor, stays on device.
-                k_cnt = xp.sum(mask_valid_b_f)
-
-                # Masked row-sum of DminusIr; zero when k_cnt == 0.
-                DminusIr_valid_rowsum = xp.sum(DminusIr * mask_valid_b_f[:, None], axis=0, keepdims=True)  # (1, P*Q)
-
-                n_high = xp.sum(mask_high_s_f)  # scalar f32
-                n_low = xp.sum(mask_low_s_f)  # scalar f32
-                R_high = xp.sum(DminusIr_valid_rowsum * mask_high_s_f[None, :]) / (k_cnt * n_high + 1e-9)
-                R_low = xp.sum(DminusIr_valid_rowsum * mask_low_s_f[None, :]) / (k_cnt * n_low + 1e-9)
-
-                b1_cand = (R_high - R_low) / (R_mean_all + 1e-9)
-
-                b_flat = xp.astype(B[:, 0], np.float32)  # (N,)
-                sum_b2 = xp.sum(b_flat**2 * mask_valid_b_f)
-                sum_b = xp.sum(b_flat * mask_valid_b_f)
-                temp1 = sum_b2
-                temp2 = sum_b
-                temp3 = b1_cand * k_cnt
-                temp4 = xp.sum(b_flat * b1_cand * mask_valid_b_f)
-                denom = temp2 * temp3 - k_cnt * temp4
-
-                # Guard against zero denominator; keep current B1 when denom ≈ 0.
-                B1_new_raw = (temp1 * temp3 - temp2 * temp4) / (denom + 1e-30)
-                B1_new_guarded = xp.where(xp.abs(denom) > 1e-30, B1_new_raw, B1)
-                B1_new = xp.minimum(B1_new_guarded, B1_uplimit / (S_mean + 1e-9))
-                # Monotonicity guard: only accept positive B1.
-                B1 = xp.where(B1_new > 0.0, B1_new, B1)
-
-                Z = B1 * (S_mean - S_spatial)  # (1, P*Q) f32, on device
-
-                # A1_offset in float64 to avoid catastrophic cancellation.
-                k_cnt_f64 = xp.astype(k_cnt, np.float64)
-                sum_b_f64 = xp.astype(sum_b, np.float64)
-                S64 = xp.astype(S_spatial, np.float64)
-                D_valid_rowsum_f64 = xp.astype(DminusIr_valid_rowsum, np.float64)
-                b_valid_mean = sum_b_f64 / (k_cnt_f64 + 1e-30)
-                A1_offset = D_valid_rowsum_f64 / (k_cnt_f64 + 1e-30) - b_valid_mean * S64  # (1, P*Q) f64
-                A_offset = A1_offset - xp.astype(Z, np.float64)  # (1, P*Q) f64
-
-                # Zero-mean centering before the proximal step.
-                A_offset_mean = xp.mean(A_offset)  # scalar f64 tensor, no sync
-                A_offset_centered = xp.astype(A_offset - A_offset_mean, np.float32)
-
-                Dr_f = xp.astype(xp.dctn(A_offset_centered.reshape(p, q), norm="ortho"), np.float32)
-                Dr_f_shrunk = shrink(xp, Dr_f, l_d / (ent2 * mu))
-                Dr = xp.astype(xp.idctn(Dr_f_shrunk.reshape(p, q), norm="ortho"), np.float32).reshape(1, p * q)
-                Dr = shrink(xp, Dr, l_d / (mu * ent2))
-                D_field = xp.astype(Dr + xp.astype(A_offset_mean, np.float32) + Z, np.float32)
-
             # 6. Update Lagrange multiplier Y (primal residual: D - Ib - Ir).
             # dY was returned by _alm_core_step; it equals D - Ib - Ir using the
             # new S_spatial/B and the current D_field (before the darkfield update).

--- a/linum_basic/_parallel.py
+++ b/linum_basic/_parallel.py
@@ -25,7 +25,14 @@ import os
 import warnings
 from collections.abc import Callable, Sequence
 
-__all__ = ["default_workers", "is_gpu_backend", "parallel_map", "resolve_workers"]
+__all__ = [
+    "default_workers",
+    "is_gpu_backend",
+    "list_cuda_devices",
+    "parallel_map",
+    "parallel_map_cuda_devices",
+    "resolve_workers",
+]
 
 
 def default_workers() -> int:
@@ -77,6 +84,41 @@ def is_gpu_backend(backend: str | None, device: str | None) -> bool:
     return False
 
 
+def list_cuda_devices(device: str | None) -> list[str]:
+    """Return CUDA device strings available for z-level parallelism.
+
+    When *device* is ``"cuda"`` (or ``None`` on a CUDA host), all visible
+    GPUs are returned.  A specific index such as ``"cuda:0"`` yields a
+    single-device list.
+
+    Parameters
+    ----------
+    device : str or None
+        PyTorch device string from BaSiC kwargs.
+
+    Returns
+    -------
+    list of str
+        Device strings, e.g. ``["cuda:0", "cuda:1"]``.  Empty when CUDA is
+        unavailable or *device* targets a non-CUDA backend.
+    """
+    dev = (device or "").lower()
+    if dev.startswith("mps"):
+        return []
+    try:
+        import torch
+    except ImportError:
+        return []
+    if not torch.cuda.is_available():
+        return []
+    dev = (device or "cuda").lower()
+    if dev in {"", "cuda"}:
+        return [f"cuda:{i}" for i in range(torch.cuda.device_count())]
+    if dev.startswith("cuda:"):
+        return [dev]
+    return []
+
+
 def resolve_workers(n_workers: int | None, backend: str | None = None, device: str | None = None) -> int:
     """Resolve a concrete worker count, applying defaults and the GPU guard.
 
@@ -97,6 +139,9 @@ def resolve_workers(n_workers: int | None, backend: str | None = None, device: s
     """
     requested = default_workers() if n_workers is None else max(1, int(n_workers))
     if is_gpu_backend(backend, device):
+        cuda_devices = list_cuda_devices(device)
+        if len(cuda_devices) > 1:
+            return min(requested, len(cuda_devices))
         if requested > 1:
             warnings.warn(
                 f"Process-based parallelism is disabled on the '{backend}' backend with device "
@@ -156,3 +201,69 @@ def parallel_map[T, R](
     with parallel_config(backend="loky", inner_max_num_threads=1, n_jobs=n_workers):
         results: list[R] = Parallel(verbose=10 if verbose else 0)(delayed(fn)(x) for x in items)
     return results
+
+
+def parallel_map_cuda_devices[T, R](
+    fn: Callable[[T, str], R],
+    items: Sequence[T],
+    devices: Sequence[str],
+    *,
+    desc: str | None = None,
+    verbose: bool = False,
+) -> list[R]:
+    """Map *fn(item, device)* over *items*, round-robin across *devices*.
+
+    Each item runs in a **separate process** with ``CUDA_VISIBLE_DEVICES`` set
+    to the assigned GPU index.  This avoids ``torch.compile`` thread-safety
+    issues and keeps VRAM isolated per device.
+
+    Order is preserved: ``result[i]`` corresponds to ``items[i]``.
+
+    Parameters
+    ----------
+    fn : callable
+        ``fn(item, device) -> result``.  *device* is always ``"cuda:0"`` inside
+        the worker (the only visible GPU in that process).
+    items : sequence
+        Work items (one per z-level tile stack).
+    devices : sequence of str
+        CUDA device strings, e.g. ``["cuda:0", "cuda:1"]``.
+    desc : str or None
+        Progress-bar label when *verbose*.
+    verbose : bool
+        Show a :mod:`tqdm` progress bar.
+
+    Returns
+    -------
+    list
+        Results in input order.
+    """
+    import os
+
+    items = list(items)
+    devs = list(devices)
+    if not items:
+        return []
+    if len(devs) == 1:
+        dev = devs[0]
+        iterator = items
+        if verbose:
+            from tqdm.auto import tqdm
+
+            iterator = tqdm(items, desc=desc, total=len(items), leave=False)
+        return [fn(item, dev) for item in iterator]
+
+    def _task(index: int, item: T, device: str) -> tuple[int, R]:
+        gpu_ix = device.rsplit(":", 1)[-1]
+        os.environ["CUDA_VISIBLE_DEVICES"] = gpu_ix
+        return index, fn(item, "cuda:0")
+
+    from joblib import Parallel, delayed, parallel_config
+
+    n_jobs = min(len(devs), len(items))
+    with parallel_config(backend="loky", inner_max_num_threads=1, n_jobs=n_jobs):
+        pairs: list[tuple[int, R]] = Parallel(verbose=10 if verbose else 0)(
+            delayed(_task)(i, item, devs[i % len(devs)]) for i, item in enumerate(items)
+        )
+    pairs.sort(key=lambda pair: pair[0])
+    return [value for _, value in pairs]

--- a/linum_basic/fit.py
+++ b/linum_basic/fit.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from linum_basic._parallel import parallel_map, resolve_workers
+from linum_basic._parallel import list_cuda_devices, parallel_map, parallel_map_cuda_devices, resolve_workers
 from linum_basic.core import BaSiC
 from linum_basic.mosaic import MosaicGrid
 
@@ -98,6 +98,29 @@ def _fit_one_z(
     model.prepare()
     model.run()
     return model.get_flatfield(), model.get_darkfield()
+
+
+def _fit_one_z_on_device(
+    tiles: np.ndarray,
+    device: str,
+    params: dict[str, Any],
+    n_extra_rows: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fit one z-level on a specific CUDA device (picklable entry point)."""
+    dev_params = dict(params)
+    dev_params["device"] = device
+    return _fit_one_z(tiles, dev_params, n_extra_rows)
+
+
+def _fit_one_z_cuda_map(
+    tiles: np.ndarray,
+    device: str,
+    *,
+    params: dict[str, Any],
+    n_extra_rows: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Module-level partial target for :func:`parallel_map_cuda_devices`."""
+    return _fit_one_z_on_device(tiles, device, params, n_extra_rows)
 
 
 @dataclass(init=False)
@@ -205,6 +228,10 @@ def fit_mosaic(
         Fitted flat/dark-fields for each requested z-level.
     """
     params: dict[str, Any] = dict(basic_kwargs or {})
+    # Warm-start inner ALM across outer reweighting passes when the cap is high.
+    if "warm_start_reweighting" not in params and int(params.get("max_reweighting_iterations", 10)) >= 5:
+        params["warm_start_reweighting"] = True
+
     z_idx = list(z_indices) if z_indices is not None else list(range(mosaic.n_z))
 
     th, tw = mosaic.tile_shape
@@ -212,17 +239,33 @@ def fit_mosaic(
     darkfields = np.zeros((len(z_idx), th, tw), dtype=np.float32)
 
     n_eff = resolve_workers(n_workers, params.get("backend"), params.get("device"))
+    cuda_devices = list_cuda_devices(params.get("device"))
+    use_cuda_fanout = (
+        len(cuda_devices) > 1
+        and params.get("backend") in {"torch", "auto"}
+        and (params.get("device") or "cuda").lower().startswith("cuda")
+    )
 
     # Pre-extract per-z tile stacks so workers receive only the slice they
     # need (cheap views into the in-memory mosaic) instead of the whole grid.
     tile_stacks = [mosaic.iter_tiles(z) for z in z_idx]
-    results = parallel_map(
-        partial(_fit_one_z, params=params, n_extra_rows=n_extra_rows),
-        tile_stacks,
-        n_eff,
-        desc="Fitting z-levels",
-        verbose=verbose,
-    )
+    if use_cuda_fanout:
+        cuda_fit = partial(_fit_one_z_cuda_map, params=params, n_extra_rows=n_extra_rows)
+        results = parallel_map_cuda_devices(
+            cuda_fit,
+            tile_stacks,
+            cuda_devices,
+            desc="Fitting z-levels (multi-GPU)",
+            verbose=verbose,
+        )
+    else:
+        results = parallel_map(
+            partial(_fit_one_z, params=params, n_extra_rows=n_extra_rows),
+            tile_stacks,
+            n_eff,
+            desc="Fitting z-levels",
+            verbose=verbose,
+        )
     for i, (flatfield, darkfield) in enumerate(results):
         flatfields[i, n_extra_rows:, :] = flatfield
         darkfields[i, n_extra_rows:, :] = darkfield

--- a/scripts/benchmark_speedup.py
+++ b/scripts/benchmark_speedup.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Compare fit_mosaic wall time: single-GPU vs multi-GPU fan-out.
+
+Designed for CUDA hosts with >= 2 GPUs.  Uses synthetic OCT-like mosaics by
+default so no data mount is required.
+
+Example (remote server)::
+
+    uv run python scripts/benchmark_speedup.py \\
+        --syn-z 16 --syn-rows 31 --syn-cols 16 --syn-th 75 --syn-tw 75 \\
+        --repeats 3 --max-reweighting-iterations 15 --estimate-darkfield
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _synthetic_mosaic(n_z: int, n_rows: int, n_cols: int, th: int, tw: int) -> Any:
+    from linum_basic.mosaic import MosaicGrid
+
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((n_z, n_rows * th, n_cols * tw)).astype(np.float32)
+    arr = np.clip(arr * 0.2 + 1.0, 0.01, None)
+    return MosaicGrid(array=arr, tile_shape=(th, tw), overlap_fraction=0.2)
+
+
+def _time_fit(mosaic: Any, basic_kwargs: dict[str, Any]) -> float:
+    from linum_basic.fit import fit_mosaic
+
+    t0 = time.perf_counter()
+    fit_mosaic(mosaic, basic_kwargs=basic_kwargs, n_workers=1, verbose=False)
+    return time.perf_counter() - t0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--syn-z", type=int, default=16)
+    p.add_argument("--syn-rows", type=int, default=31)
+    p.add_argument("--syn-cols", type=int, default=16)
+    p.add_argument("--syn-th", type=int, default=75)
+    p.add_argument("--syn-tw", type=int, default=75)
+    p.add_argument("--working-size", type=int, default=128)
+    p.add_argument("--repeats", type=int, default=3)
+    p.add_argument("--max-reweighting-iterations", type=int, default=15)
+    p.add_argument("--estimate-darkfield", action=argparse.BooleanOptionalAction, default=True)
+    p.add_argument("--output", default="/tmp/benchmark_speedup.json")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        import torch
+    except ImportError:
+        print("PyTorch required", file=sys.stderr)
+        return 1
+    if not torch.cuda.is_available():
+        print("CUDA required", file=sys.stderr)
+        return 1
+
+    from linum_basic._parallel import list_cuda_devices
+
+    devices = list_cuda_devices("cuda")
+    print(f"Host: {platform.node()}  GPUs: {devices}")
+
+    mosaic = _synthetic_mosaic(args.syn_z, args.syn_rows, args.syn_cols, args.syn_th, args.syn_tw)
+    print(
+        f"Mosaic: {mosaic.n_z}z x {mosaic.n_rows}x{mosaic.n_cols} tiles ({mosaic.n_tiles}/z)  tile {args.syn_th}x{args.syn_tw}"
+    )
+
+    single_kwargs: dict[str, Any] = {
+        "backend": "torch",
+        "device": "cuda:0",
+        "working_size": args.working_size,
+        "estimate_darkfield": args.estimate_darkfield,
+        "max_reweighting_iterations": args.max_reweighting_iterations,
+        "warm_start_reweighting": False,
+    }
+    multi_kwargs: dict[str, Any] = {
+        **single_kwargs,
+        "device": "cuda",
+        "warm_start_reweighting": True,
+    }
+
+    single_times: list[float] = []
+    multi_times: list[float] = []
+    for rep in range(args.repeats):
+        t_single = _time_fit(mosaic, single_kwargs)
+        single_times.append(t_single)
+        print(f"  single-GPU rep {rep + 1}/{args.repeats}: {t_single:.2f}s")
+    for rep in range(args.repeats):
+        t_multi = _time_fit(mosaic, multi_kwargs)
+        multi_times.append(t_multi)
+        print(f"  multi-GPU  rep {rep + 1}/{args.repeats}: {t_multi:.2f}s")
+
+    single_mean = float(np.mean(single_times))
+    multi_mean = float(np.mean(multi_times))
+    speedup = single_mean / multi_mean if multi_mean > 0 else float("nan")
+
+    print("\n" + "=" * 50)
+    print(f"single-GPU (cuda:0):  {single_mean:.2f}s mean")
+    print(f"multi-GPU  (cuda):    {multi_mean:.2f}s mean")
+    print(f"speedup:              {speedup:.2f}x")
+    print("=" * 50)
+
+    out = {
+        "host": platform.node(),
+        "gpus": devices,
+        "single_gpu_mean_s": single_mean,
+        "multi_gpu_mean_s": multi_mean,
+        "speedup": speedup,
+        "single_times": single_times,
+        "multi_times": multi_times,
+        "kwargs": {"single": single_kwargs, "multi": multi_kwargs},
+    }
+    Path(args.output).write_text(json.dumps(out, indent=2))
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -10,6 +10,7 @@ import pytest
 from linum_basic._parallel import (
     default_workers,
     is_gpu_backend,
+    list_cuda_devices,
     parallel_map,
     resolve_workers,
 )
@@ -65,7 +66,38 @@ def test_resolve_workers_gpu_guard_forces_one() -> None:
     assert resolve_workers(4, "torch", "cpu") == 4
     assert resolve_workers(4, "auto", "mps") == 1
     with pytest.warns(UserWarning, match="sequentially"):
-        assert resolve_workers(4, "torch", "cuda") == 1
+        assert resolve_workers(4, "torch", "cuda:0") == 1
+
+
+def test_list_cuda_devices_explicit_index() -> None:
+    try:
+        import torch
+    except ImportError:
+        pytest.skip("torch not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    assert list_cuda_devices("cuda:0") == ["cuda:0"]
+
+
+def test_fit_mosaic_multi_gpu_matches_sequential() -> None:
+    try:
+        import torch
+    except ImportError:
+        pytest.skip("torch not installed")
+    if torch.cuda.device_count() < 2:
+        pytest.skip("needs >= 2 CUDA devices")
+    mosaic = _make_mosaic(n_z=4, n_rows=2, n_cols=2, th=8, tw=8, seed=7)
+    basic_kwargs = {
+        "estimate_darkfield": True,
+        "working_size": 8,
+        "backend": "torch",
+        "device": "cuda",
+        "max_reweighting_iterations": 3,
+    }
+    seq = fit_mosaic(mosaic, basic_kwargs=basic_kwargs, n_workers=1)
+    par = fit_mosaic(mosaic, basic_kwargs=basic_kwargs, n_workers=2)
+    assert np.allclose(seq.flatfields, par.flatfields, atol=1e-4)
+    assert np.allclose(seq.darkfields, par.darkfields, atol=1e-4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fan independent per-z BaSiC solves across all visible CUDA devices when `device="cuda"` (process pool with per-worker `CUDA_VISIBLE_DEVICES`).
- Fold darkfield DCT/update into the GPU-compiled ALM step; fix per-device compile cache keys.
- Auto-enable `warm_start_reweighting` when `max_reweighting_iterations >= 5`.
- Add `scripts/benchmark_speedup.py` for before/after timing on multi-GPU hosts.

## Benchmark (server: 2× RTX A6000, 16 z × 496 tiles, darkfield on)
- Single GPU (`cuda:0`): **45.8 s** mean
- Multi-GPU (`cuda`): **22.3 s** mean → **2.05× speedup**
- Tests: **365 passed** on server

## Test plan
- [x] `uv run pytest tests/` on CUDA server (365 passed)
- [x] `scripts/benchmark_speedup.py` on dual-A6000 host
- [x] Merge linumpy PR that exposes all GPUs in `fix_illumination_basic` (companion PR)